### PR TITLE
docs: fix attributes hook param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ use Syntatis\WPHook\Action;
 use Syntatis\WPHook\Filter;
 use Syntatis\WPHook\Hook;
 
-#[Action(tag: "wp")]
+#[Action(name: "wp")]
 class HelloWorld
 {
-    #[Action(tag: "init")]
+    #[Action(name: "init")]
     public function initialise(): void
     {
       echo 'initialise';
     }
 
-    #[Filter(tag: "the_content", priority: 100)]
+    #[Filter(name: "the_content", priority: 100)]
     public function content(string $content): string
     {
       return $content . "\ncontent";


### PR DESCRIPTION
The example in the documentation has the wrong parameter name. It should be `name` instead of `tag`.

https://github.com/syntatis/wp-hook/blob/d22ce6ae1218b28971cf3b1701cb1b6c2ce43055/app/Attributes/Model.php#L12